### PR TITLE
DOC: Fix the GitHub pages deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Once the feature at issue has been verified, push the code to a new branch
 following the regular `git` collaborative model so that it can be merged into
 `main`.
 
-Check out the `gh-pages` branch and deploy website to GitHub pages using:
+Once the feature merged into `main`, deploy the website to GitHub pages using:
 
 ```console
 $ npm run deploy -- -m "Deploy React app to GitHub Pages"


### PR DESCRIPTION
Fix the GitHub pages deployment instructions: the deployment is done from the `main` branch, which will take care of deploying it to the branch configured in GitHub (e.g. `gh-pages`) for the deployment. So remove the `gh-pages` checkout part.

Take advantage of the commit to fix grammar in the deployment section.