### PR TITLE
ENH: Reuse schedule descriptions in speaker components

### DIFF
--- a/src/components/speakers/Data.js
+++ b/src/components/speakers/Data.js
@@ -3,42 +3,36 @@ import { Gjacobs, Nkarani, Pwang, Sabbasirad, Slariviere, Xzeng } from '../../as
 const speakers = [
     {
         title: 'Shahrokh Abbasi-Rad',
-        desc: 'Adiabatic null passage for on-resonance magnetization transfer preparation',
         src: Sabbasirad,
         site: 'https://lcn.martinos.org/people',
         institution: 'Laboratories for Computational Neuroimaging (LCN), Martinos'
     },
     {
         title: 'Grace Jacobs',
-        desc: 'Deviations in white matter microstructure and freewater vary across individuals at clinical high risk for psychosis',
         src: Gjacobs,
         site: 'https://pnl.bwh.harvard.edu/',
         institution: 'Psychiatry Neuroimaging Laboratory (PNL), BWH'
     },
     {
         title: 'Neerav Karani',
-        desc: 'Boundary-weighted logit consistency improves calibration of segmentation networks',
         src: Nkarani,
         site: 'https://people.csail.mit.edu/polina/people.html',
         institution: 'Computer Science and Artificial Intelligence Laboratory (CSAIL), MIT'
     },
     {
         title: 'Sara Larivière',
-        desc: 'Multimodal network mapping in epilepsy',
         src: Slariviere,
         site: 'https://www.brighamandwomens.org/neurosciences-center/center-for-brain-circuit-therapeutics',
         institution: 'Center for Brain Circuit Therapeutic, BWH'
     },
     {
         title: 'Peiqi Wang',
-        desc: 'Sample-specific debiasing for better image-text models',
         src: Pwang,
         site: 'https://people.csail.mit.edu/polina/people.html',
         institution: 'Computer Science and Artificial Intelligence Laboratory (CSAIL), MIT'
     },
     {
         title: 'Xiangrui (Taylor) Zeng',
-        desc: 'Segmentation of supragranular and infragranular layers in ultra-high resolution 7T ex vivo MRI of the human cerebral cortex',
         src: Xzeng,
         site: 'https://lcn.martinos.org/people/',
         institution: 'Laboratories for Computational Neuroimaging (LCN), Martinos'

--- a/src/components/speakers/Speakers.js
+++ b/src/components/speakers/Speakers.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Title from '../layouts/Title';
 import Card from './Card';
 import speakers from './Data';
+import schedule from '../schedule/Data';
 
 const Speakers = () => {
     return (
@@ -14,7 +15,7 @@ const Speakers = () => {
                     <Card
                         key={index}
                         title={item.title}
-                        desc={item.desc}
+                        desc={schedule.find(x => x.title === item.title).desc}
                         src={item.src}
                         site={item.site}
                         institution={item.institution}


### PR DESCRIPTION
Reuse talk titles stored in schedule descriptions in speaker components. Avoids redundancy with speaker detail data.