### PR TITLE
STYLE: Improve team card appearance

### DIFF
--- a/src/components/team/Card.js
+++ b/src/components/team/Card.js
@@ -13,7 +13,7 @@ const Card = (props) => {
                         />
                     </div>
                     <div className="flex flex-col gap-6">
-                        <h2 className="text-xl md:text-2xl font-titleFont font-bold text-gray-300">
+                        <h2 className="text-md md:text-2md font-titleFont font-bold text-gray-300">
                             {props.title}
                         </h2>
                         <p className='base'>

--- a/src/components/team/Team.js
+++ b/src/components/team/Team.js
@@ -9,7 +9,7 @@ const Team = () => {
             <div className="flex justify-center items-center text-center">
                 <Title title='We look forward to seeing you!' body='Team' />
             </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-4 xl:gap-10">
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-4 xl:gap-2">
                 {members.map((item, index) => (
                     <Card
                         title={item.title}


### PR DESCRIPTION
Improve team card appearance:
- Reduce the text font size
- Reduce the gap between cards

Avoids the pictures to overflow the cards, especially for those cases where the affiliations span over two rows.