### PR TITLE
ENH: Add registration requirement notice

### DIFF
--- a/src/components/banner/Media.js
+++ b/src/components/banner/Media.js
@@ -5,7 +5,7 @@ const Media = () => {
         <div className="flex flex-col xl:flex-row gap-6 lgl:gap-0 justify-between items-center lgl:items-start">
             <div>
                 <h2 className="text-base uppercase font-titleFont mb-4 text-center lgl:text-left">
-                    Find us in Boston
+                    Registration required
                 </h2>
             </div>
         </div>


### PR DESCRIPTION
Make it explicit that registration to the event is required: change the inconsequential "Find us in Boston" message for the "Registration required" message.